### PR TITLE
Add self-hosted FastAPI backend for StudyBuddy

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,80 @@
+# StudyBuddy Backend
+
+This folder contains a self-hosted FastAPI service that mirrors the behaviour of the original Google AI integration used by the StudyBuddy frontend.  The service wraps a locally hosted large language model (LLM) and an optional image generation pipeline so you can run the entire workflow on-premise without relying on Google APIs.
+
+## Features
+
+- **Flashcards** – `POST /flashcards` converts uploaded source material into question/answer pairs.
+- **Practice exam** – `POST /practice-exam` returns multiple choice questions with the correct answer flagged.
+- **Summary with images** – `POST /summary-with-images` produces a Markdown summary and inlines `data:` URLs for any generated images.
+- **Chat continuation** – `POST /chat` appends a new assistant response to an existing conversation.
+- **Health check** – `GET /health` confirms the service is up.
+
+All endpoints accept and return exactly the same payloads that the frontend expects from `services/geminiService.ts`, so you can switch the UI over to this backend by replacing the Google client with `fetch` calls.
+
+## Model choices (<= 16 GB VRAM)
+
+The defaults target readily available open models that comfortably run on a single 16 GB GPU when loaded in half precision:
+
+- **Text generation** – [`mistralai/Mistral-7B-Instruct-v0.2`](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2)
+- **Image generation** – [`stabilityai/stable-diffusion-2-1-base`](https://huggingface.co/stabilityai/stable-diffusion-2-1-base)
+
+You can swap either model by setting the environment variables listed below.
+
+> [!TIP]
+> When running entirely on CPU the service still works, but responses will be significantly slower.  The code automatically switches to float32 and CPU execution when CUDA is unavailable.
+
+## Quick start
+
+1. **Install dependencies**
+
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **(Optional) Configure models**
+
+   Create a `.env` file inside `backend/` to override defaults:
+
+   ```bash
+   echo "STUDYBUDDY_TEXT_MODEL_ID=mistralai/Mixtral-8x7B-Instruct-v0.1" >> .env
+   echo "STUDYBUDDY_ENABLE_IMAGE_GENERATION=false" >> .env  # disable the image pipeline
+   ```
+
+3. **Run the API**
+
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+
+   The server listens on `http://127.0.0.1:8000` by default.
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `STUDYBUDDY_TEXT_MODEL_ID` | `mistralai/Mistral-7B-Instruct-v0.2` | Hugging Face model id for text generation. |
+| `STUDYBUDDY_IMAGE_MODEL_ID` | `stabilityai/stable-diffusion-2-1-base` | Diffusers checkpoint for image generation. |
+| `STUDYBUDDY_MAX_NEW_TOKENS` | `512` | Cap on generated tokens per request. |
+| `STUDYBUDDY_TEMPERATURE` | `0.7` | Sampling temperature for the LLM. |
+| `STUDYBUDDY_ENABLE_IMAGE_GENERATION` | `true` | Set to `false` to skip image creation entirely. |
+
+## Frontend integration
+
+Update `services/geminiService.ts` to replace the Google client with REST calls to the endpoints above.  The payload shapes can stay identical to the current implementation, so the rest of the React components continue working unchanged.
+
+## Testing the endpoints
+
+With the server running you can send a request using `curl` or any API client:
+
+```bash
+curl -X POST http://127.0.0.1:8000/flashcards \
+  -H "Content-Type: application/json" \
+  -d '{"scriptContent": "## Sample script\nThe mitochondria is the powerhouse of the cell."}'
+```
+
+Each endpoint returns either JSON or plain text (for `/chat`), and FastAPI automatically produces OpenAPI docs at `http://127.0.0.1:8000/docs`.
+

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,5 @@
+"""StudyBuddy backend package."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,39 @@
+from functools import lru_cache
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the StudyBuddy backend."""
+
+    text_model_id: str = Field(
+        default="mistralai/Mistral-7B-Instruct-v0.2",
+        description="Hugging Face model id used for text generation.",
+    )
+    image_model_id: str = Field(
+        default="stabilityai/stable-diffusion-2-1-base",
+        description="Diffusers checkpoint id used for image generation.",
+    )
+    max_new_tokens: int = Field(
+        default=512,
+        description="Maximum number of tokens to generate for a single request.",
+    )
+    temperature: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=2.0,
+        description="Sampling temperature applied to the LLM.",
+    )
+    enable_image_generation: bool = Field(
+        default=True,
+        description="Disable to skip image creation while still returning a textual summary.",
+    )
+
+    class Config:
+        env_prefix = "STUDYBUDDY_"
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()  # type: ignore[call-arg]

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -1,0 +1,96 @@
+"""Utilities for loading and interacting with local AI models."""
+
+from __future__ import annotations
+
+import base64
+import io
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from diffusers import StableDiffusionPipeline
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+from .config import Settings, get_settings
+
+
+@dataclass
+class GenerationResult:
+    """Container describing generated text."""
+
+    text: str
+
+
+class TextGenerationClient:
+    """Wrapper around a Hugging Face causal language model."""
+
+    def __init__(self, settings: Optional[Settings] = None) -> None:
+        self.settings = settings or get_settings()
+        self._tokenizer = AutoTokenizer.from_pretrained(self.settings.text_model_id)
+        self._model = AutoModelForCausalLM.from_pretrained(
+            self.settings.text_model_id,
+            torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
+            device_map="auto",
+        )
+        self._pipeline = pipeline(
+            "text-generation",
+            model=self._model,
+            tokenizer=self._tokenizer,
+            return_full_text=False,
+        )
+
+        # Some models (e.g. Mistral) lack an explicit pad token, so align with EOS.
+        if self._pipeline.tokenizer.pad_token_id is None:
+            self._pipeline.tokenizer.pad_token_id = self._pipeline.tokenizer.eos_token_id
+
+    def generate(self, prompt: str, max_new_tokens: Optional[int] = None, temperature: Optional[float] = None) -> GenerationResult:
+        settings = self.settings
+        temperature = temperature if temperature is not None else settings.temperature
+        max_new_tokens = max_new_tokens if max_new_tokens is not None else settings.max_new_tokens
+
+        do_sample = temperature > 0
+        outputs = self._pipeline(
+            prompt,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            temperature=temperature if do_sample else None,
+            top_p=0.9 if do_sample else None,
+            eos_token_id=self._pipeline.tokenizer.eos_token_id,
+        )
+        text = outputs[0]["generated_text"].strip()
+        return GenerationResult(text=text)
+
+
+class ImageGenerationClient:
+    """Wrapper around a Diffusers Stable Diffusion pipeline."""
+
+    def __init__(self, settings: Optional[Settings] = None) -> None:
+        self.settings = settings or get_settings()
+        if not self.settings.enable_image_generation:
+            self._pipeline = None
+            return
+
+        torch_dtype = torch.float16 if torch.cuda.is_available() else torch.float32
+        self._pipeline = StableDiffusionPipeline.from_pretrained(
+            self.settings.image_model_id,
+            torch_dtype=torch_dtype,
+            safety_checker=None,
+        )
+        if torch.cuda.is_available():
+            self._pipeline.to("cuda")
+        else:
+            self._pipeline.to("cpu")
+
+    def generate(self, prompt: str) -> str:
+        if not self.settings.enable_image_generation or self._pipeline is None:
+            raise RuntimeError("Image generation is disabled in the current configuration.")
+
+        if torch.cuda.is_available():
+            with torch.autocast("cuda"):
+                image = self._pipeline(prompt).images[0]
+        else:
+            image = self._pipeline(prompt).images[0]
+        buffer = io.BytesIO()
+        image.save(buffer, format="JPEG", quality=90)
+        encoded = base64.b64encode(buffer.getvalue()).decode("utf-8")
+        return encoded

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,92 @@
+"""FastAPI entry point exposing the StudyBuddy REST API."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.concurrency import run_in_threadpool
+
+from .config import get_settings
+from .schemas import (
+    ChatRequest,
+    ChatResponse,
+    ExamResponse,
+    FlashcardResponse,
+    ScriptRequest,
+    SummaryResponse,
+)
+from .service import StudyBuddyService, get_service
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="StudyBuddy Backend", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def healthcheck():
+    settings = get_settings()
+    return {
+        "status": "ok",
+        "textModel": settings.text_model_id,
+        "imageModel": settings.image_model_id if settings.enable_image_generation else None,
+    }
+
+
+@app.post("/flashcards", response_model=FlashcardResponse)
+async def flashcards(
+    payload: ScriptRequest,
+    service: StudyBuddyService = Depends(get_service),
+):
+    items = await run_in_threadpool(service.generate_flashcards, payload.scriptContent)
+    return FlashcardResponse(__root__=items)
+
+
+@app.post("/practice-exam", response_model=ExamResponse)
+async def practice_exam(
+    payload: ScriptRequest,
+    service: StudyBuddyService = Depends(get_service),
+):
+    questions = await run_in_threadpool(service.generate_practice_exam, payload.scriptContent)
+    return ExamResponse(__root__=questions)
+
+
+@app.post("/summary-with-images", response_model=SummaryResponse)
+async def summary_with_images(
+    payload: ScriptRequest,
+    service: StudyBuddyService = Depends(get_service),
+):
+    summary = await run_in_threadpool(service.generate_summary_with_images, payload.scriptContent)
+    return SummaryResponse(summary=summary)
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(
+    payload: ChatRequest,
+    service: StudyBuddyService = Depends(get_service),
+):
+    try:
+        reply = await run_in_threadpool(
+            service.continue_chat, payload.history, payload.systemInstruction, payload.message
+        )
+    except HTTPException:
+        raise
+    return ChatResponse(message=reply)
+
+
+__all__ = ["app"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    import uvicorn
+
+    uvicorn.run("backend.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+pydantic==2.7.1
+python-dotenv==1.0.1
+transformers==4.40.2
+torch==2.2.2
+accelerate==0.30.1
+diffusers==0.27.2
+safetensors==0.4.3

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,53 @@
+"""Pydantic models shared by the FastAPI endpoints."""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class Flashcard(BaseModel):
+    question: str = Field(..., description="Front of the flashcard")
+    answer: str = Field(..., description="Back of the flashcard")
+
+
+class ExamQuestion(BaseModel):
+    question: str
+    options: List[str]
+    correctAnswer: str
+
+
+class ScriptRequest(BaseModel):
+    scriptContent: str = Field(..., description="Concatenated project files")
+
+
+class FlashcardResponse(BaseModel):
+    __root__: List[Flashcard]
+
+
+class ExamResponse(BaseModel):
+    __root__: List[ExamQuestion]
+
+
+class SummaryResponse(BaseModel):
+    summary: str
+
+
+class ChatPart(BaseModel):
+    text: str
+
+
+class ChatMessage(BaseModel):
+    role: str
+    parts: List[ChatPart]
+
+
+class ChatRequest(BaseModel):
+    history: List[ChatMessage]
+    systemInstruction: str
+    message: str
+
+
+class ChatResponse(BaseModel):
+    message: str

--- a/backend/service.py
+++ b/backend/service.py
@@ -1,0 +1,176 @@
+"""Domain logic for converting StudyBuddy requests into LLM prompts."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from functools import lru_cache
+from typing import List
+
+from fastapi import HTTPException, status
+
+from .config import Settings, get_settings
+from .llm import GenerationResult, ImageGenerationClient, TextGenerationClient
+from .schemas import ChatMessage, ExamQuestion, Flashcard
+
+logger = logging.getLogger(__name__)
+
+IMAGE_PROMPT_REGEX = re.compile(r"\[IMAGE_PROMPT:\s*(.*?)\s*\]")
+
+
+class StudyBuddyService:
+    """High-level orchestrator for all API endpoints."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._text_client = TextGenerationClient(self.settings)
+        self._image_client = ImageGenerationClient(self.settings)
+
+    # ------------------------------------------------------------------
+    # Flashcards
+    # ------------------------------------------------------------------
+    def generate_flashcards(self, script_content: str) -> List[Flashcard]:
+        prompt = (
+            "You are an educational assistant. Read the study material below and generate a JSON array of flashcards. "
+            "Each entry must have the keys 'question' and 'answer'. Focus on the most important facts, definitions, and concepts.\n\n"
+            "Study material:\n" + script_content + "\n\nReturn only valid JSON."
+        )
+        result = self._safe_generate(prompt, max_new_tokens=768)
+        return self._parse_json_array(result.text, Flashcard)
+
+    # ------------------------------------------------------------------
+    # Practice Exam
+    # ------------------------------------------------------------------
+    def generate_practice_exam(self, script_content: str) -> List[ExamQuestion]:
+        prompt = (
+            "You are preparing a multiple choice practice exam. Based on the study material below, create at least five questions. "
+            "Return a JSON array where every object has the keys 'question', 'options' (exactly four), and 'correctAnswer' which must match one of the options.\n\n"
+            "Study material:\n" + script_content + "\n\nReturn only valid JSON."
+        )
+        result = self._safe_generate(prompt, max_new_tokens=1024)
+        questions = self._parse_json_array(result.text, ExamQuestion)
+        for question in questions:
+            if len(question.options) != 4:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="Generated exam question does not have exactly four options.",
+                )
+            if question.correctAnswer not in question.options:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="Generated exam question has a correctAnswer that is not one of the options.",
+                )
+        return questions
+
+    # ------------------------------------------------------------------
+    # Summary + images
+    # ------------------------------------------------------------------
+    def generate_summary_with_images(self, script_content: str) -> str:
+        prompt = (
+            "Create a structured Markdown summary of the study material below. Write in concise sections with headings and bullet points when useful. "
+            "When a visual aid would help, insert a placeholder exactly in the form [IMAGE_PROMPT: description of the scene]. Limit to at most 3 images.\n\n"
+            "Study material:\n" + script_content + "\n\nReturn only the Markdown summary."
+        )
+        result = self._safe_generate(prompt, max_new_tokens=1024)
+        markdown = result.text
+
+        prompts = IMAGE_PROMPT_REGEX.findall(markdown)
+        if not prompts:
+            return markdown
+
+        if not self.settings.enable_image_generation:
+            def _disabled(_: re.Match[str]) -> str:
+                return (
+                    "\n\n<div class=\"my-6 p-4 bg-gray-700/50 border border-blue-500/50 rounded-lg text-center text-blue-200\">"
+                    f"<em>Image prompt: {_.group(1).strip()} (image generation disabled)</em></div>\n\n"
+                )
+
+            return IMAGE_PROMPT_REGEX.sub(_disabled, markdown)
+
+        replacements: List[str] = []
+        for prompt_text in prompts:
+            try:
+                image_b64 = self._image_client.generate(prompt_text)
+                replacements.append(
+                    f'\n\n<img src="data:image/jpeg;base64,{image_b64}" alt="{prompt_text}" class="my-6 rounded-lg shadow-lg w-full" />\n\n'
+                )
+            except Exception as exc:  # pragma: no cover - hardware dependent
+                logger.exception("Failed to generate image for prompt '%s'", prompt_text)
+                replacements.append(
+                    "\n\n<div class=\"my-6 p-4 bg-gray-700/50 border border-red-500/50 rounded-lg text-center text-red-400\"><em>"
+                    + f"Image generation failed for prompt: {prompt_text}."
+                    + "</em></div>\n\n"
+                )
+
+        def _replacement(_: re.Match[str]) -> str:
+            return replacements.pop(0) if replacements else ""
+
+        return IMAGE_PROMPT_REGEX.sub(_replacement, markdown)
+
+    # ------------------------------------------------------------------
+    # Chat
+    # ------------------------------------------------------------------
+    def continue_chat(self, history: List[ChatMessage], system_instruction: str, message: str) -> str:
+        conversation = self._render_history(history)
+        prompt = (
+            f"{system_instruction.strip()}\n\n"
+            "The following is a conversation between a helpful study assistant and a user. Respond with clear, actionable explanations.\n"
+            f"Conversation so far:\n{conversation}\nUser: {message}\nAssistant:"
+        )
+        result = self._safe_generate(prompt, max_new_tokens=512)
+        return result.text
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _safe_generate(self, prompt: str, max_new_tokens: int) -> GenerationResult:
+        try:
+            return self._text_client.generate(prompt, max_new_tokens=max_new_tokens)
+        except HTTPException:
+            raise
+        except Exception as exc:  # pragma: no cover - depends on runtime
+            logger.exception("Text generation failed")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Text generation failed: {exc}",
+            ) from exc
+
+    def _parse_json_array(self, payload: str, model_cls):
+        try:
+            data = json.loads(self._extract_json(payload))
+        except json.JSONDecodeError as exc:
+            logger.error("Failed to parse JSON payload: %s", payload)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="The language model returned malformed JSON.",
+            ) from exc
+        if not isinstance(data, list):
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="The language model returned a payload that was not a JSON array.",
+            )
+        return [model_cls(**item) for item in data]
+
+    @staticmethod
+    def _extract_json(text: str) -> str:
+        text = text.strip()
+        if text.startswith("```"):
+            fence_end = text.find("```", 3)
+            if fence_end != -1:
+                return text[3:fence_end].strip()
+        return text
+
+    @staticmethod
+    def _render_history(history: List[ChatMessage]) -> str:
+        rendered_turns: List[str] = []
+        for entry in history:
+            speaker = "User" if entry.role == "user" else "Assistant"
+            for part in entry.parts:
+                rendered_turns.append(f"{speaker}: {part.text}")
+        return "\n".join(rendered_turns)
+
+
+@lru_cache
+def get_service() -> StudyBuddyService:
+    return StudyBuddyService(get_settings())


### PR DESCRIPTION
## Summary
- add a FastAPI backend that mirrors the original Google AI endpoints with flashcards, practice exam, summary, and chat routes
- integrate Hugging Face text generation and Stable Diffusion pipelines configurable to stay within a 16 GB VRAM budget
- document setup steps, runtime configuration, and environment variables for running the backend locally

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68f284ee89f08328a86ab5d86737a393